### PR TITLE
Add missingstring for saving, and reorgnize tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ save(Stream(format"CSV", io), it)
 
 The ``save`` function takes a number of arguments:
 ````julia
-save(f::FileIO.File{FileIO.format"CSV"}, data; delim=',', quotechar='"', escapechar='\\', header=true)
+save(f::FileIO.File{FileIO.format"CSV"}, data; delim=',', quotechar='"', escapechar='\\', missingstring="NA", header=true)
 ````
 
 #### Arguments
@@ -104,6 +104,7 @@ save(f::FileIO.File{FileIO.format"CSV"}, data; delim=',', quotechar='"', escapec
 * ``delim``: the delimiter character, defaults to ``,``.
 * ``quotechar``: character used to quote strings, defaults to ``"``.
 * ``escapechar``: character used to escape ``quotechar`` in strings, defaults to ``\``.
+* ``missingstring``: string to insert in the place of missing values, defaults to ``NA``.
 * ``header``: whether a header should be written, defaults to ``true.
 
 ### Using the pipe syntax

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ save(Stream(format"CSV", io), it)
 
 The ``save`` function takes a number of arguments:
 ````julia
-save(f::FileIO.File{FileIO.format"CSV"}, data; delim=',', quotechar='"', escapechar='\\', missingstring="NA", header=true)
+save(f::FileIO.File{FileIO.format"CSV"}, data; delim=',', quotechar='"', escapechar='\\', nastring="NA", header=true)
 ````
 
 #### Arguments
@@ -104,7 +104,7 @@ save(f::FileIO.File{FileIO.format"CSV"}, data; delim=',', quotechar='"', escapec
 * ``delim``: the delimiter character, defaults to ``,``.
 * ``quotechar``: character used to quote strings, defaults to ``"``.
 * ``escapechar``: character used to escape ``quotechar`` in strings, defaults to ``\``.
-* ``missingstring``: string to insert in the place of missing values, defaults to ``NA``.
+* ``nastring``: string to insert in the place of missing values, defaults to ``NA``.
 * ``header``: whether a header should be written, defaults to ``true.
 
 ### Using the pipe syntax

--- a/src/csv_writer.jl
+++ b/src/csv_writer.jl
@@ -73,11 +73,20 @@ function _save(filename::AbstractString, data; delim=',', quotechar='"', escapec
     end
 end
 
-for (FMT, odelim) in ((:CSV, ","), (:TSV, "\t"))
-    for (FF, field) in ((:File, :filename), (:Stream, :io))
-        @eval function fileio_save(f::FileIO.$FF{FileIO.DataFormat{$(Meta.quot(FMT))}}, data; delim=$odelim, quotechar='"', escapechar='\\', nastring="NA", header=true)
-            return _save(f.$field, data, delim=delim, quotechar=quotechar, escapechar=escapechar, nastring=nastring, header=header)
-        end
-    end
+
+
+function fileio_save(f::FileIO.File{FileIO.format"CSV"}, data; delim=',', quotechar='"', escapechar='\\', nastring="NA", header=true)
+    return _save(f.filename, data, delim=delim, quotechar=quotechar, escapechar=escapechar, nastring=nastring, header=header)
 end
 
+function fileio_save(f::FileIO.File{FileIO.format"TSV"}, data; delim='\t', quotechar='"', escapechar='\\', nastring="NA", header=true)
+    return _save(f.filename, data, delim=delim, quotechar=quotechar, escapechar=escapechar, nastring=nastring, header=header)
+end
+
+function fileio_save(s::FileIO.Stream{FileIO.format"CSV"}, data; delim=',', quotechar='"', escapechar='\\', nastring="NA", header=true)
+    return _save(s.io, data, delim=delim, quotechar=quotechar, escapechar=escapechar, nastring=nastring, header=header)
+end
+
+function fileio_save(s::FileIO.Stream{FileIO.format"TSV"}, data; delim='\t', quotechar='"', escapechar='\\', nastring="NA", header=true)
+    return _save(s.io, data, delim=delim, quotechar=quotechar, escapechar=escapechar, nastring=nastring, header=header)
+end

--- a/src/csv_writer.jl
+++ b/src/csv_writer.jl
@@ -1,4 +1,4 @@
-function _writevalue(io::IO, value::String, delim, quotechar, escapechar, missingstring)
+function _writevalue(io::IO, value::String, delim, quotechar, escapechar, nastring)
     if isnull(quotechar)
         print(io, value)
     else
@@ -14,25 +14,25 @@ function _writevalue(io::IO, value::String, delim, quotechar, escapechar, missin
     end
 end
 
-function _writevalue(io::IO, value, delim, quotechar, escapechar, missingstring)
+function _writevalue(io::IO, value, delim, quotechar, escapechar, nastring)
     print(io, value)
 end
 
-function _writevalue{T}(io::IO, value::DataValue{T}, delim, quotechar, escapechar, missingstring)
+function _writevalue{T}(io::IO, value::DataValue{T}, delim, quotechar, escapechar, nastring)
     if isnull(value)
-        print(io, missingstring)
+        print(io, nastring)
     else
-        _writevalue(io, get(value), delim, quotechar, escapechar, missingstring)
+        _writevalue(io, get(value), delim, quotechar, escapechar, nastring)
     end
 end
 
 
-@generated function _writecsv{T}(io::IO, it, ::Type{T}, delim, quotechar, escapechar, missingstring)
+@generated function _writecsv{T}(io::IO, it, ::Type{T}, delim, quotechar, escapechar, nastring)
     col_names = fieldnames(T)
     n = length(col_names)
     push_exprs = Expr(:block)
     for i in 1:n
-        push!(push_exprs.args, :( _writevalue(io, i.$(col_names[i]), delim, quotechar, escapechar, missingstring) ))
+        push!(push_exprs.args, :( _writevalue(io, i.$(col_names[i]), delim, quotechar, escapechar, nastring) ))
         if i<n
             push!(push_exprs.args, :( print(io, delim ) ))
         end
@@ -46,7 +46,7 @@ end
     end
 end
 
-function _save(io, data; delim=',', quotechar='"', escapechar='\\', missingstring="NA", header=true)
+function _save(io, data; delim=',', quotechar='"', escapechar='\\', nastring="NA", header=true)
     isiterabletable(data) || error("Can't write this data to a CSV file.")
 
     it = getiterator(data)
@@ -62,21 +62,21 @@ function _save(io, data; delim=',', quotechar='"', escapechar='\\', missingstrin
         end
         println(io)
     end
-    _writecsv(io, it, eltype(it), delim, quotechar_internal, escapechar, missingstring)
+    _writecsv(io, it, eltype(it), delim, quotechar_internal, escapechar, nastring)
 end
 
-function _save(filename::AbstractString, data; delim=',', quotechar='"', escapechar='\\', missingstring="NA", header=true)
+function _save(filename::AbstractString, data; delim=',', quotechar='"', escapechar='\\', nastring="NA", header=true)
     isiterabletable(data) || error("Can't write this data to a CSV file.")
 
     open(filename, "w") do io
-        _save(io, data, delim=delim, quotechar=quotechar, escapechar=escapechar, missingstring=missingstring,  header=header)
+        _save(io, data, delim=delim, quotechar=quotechar, escapechar=escapechar, nastring=nastring,  header=header)
     end
 end
 
 for (FMT, odelim) in ((:CSV, ","), (:TSV, "\t"))
     for (FF, field) in ((:File, :filename), (:Stream, :io))
-        @eval function fileio_save(f::FileIO.$FF{FileIO.DataFormat{$(Meta.quot(FMT))}}, data; delim=$odelim, quotechar='"', escapechar='\\', missingstring="NA", header=true)
-            return _save(f.$field, data, delim=delim, quotechar=quotechar, escapechar=escapechar, missingstring=missingstring, header=header)
+        @eval function fileio_save(f::FileIO.$FF{FileIO.DataFormat{$(Meta.quot(FMT))}}, data; delim=$odelim, quotechar='"', escapechar='\\', nastring="NA", header=true)
+            return _save(f.$field, data, delim=delim, quotechar=quotechar, escapechar=escapechar, nastring=nastring, header=header)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,7 +48,7 @@ end
         output_filename2 = tempname() * ".csv"
 
         try
-            array3 |> save(output_filename2, missingstring="")
+            array3 |> save(output_filename2, nastring="")
         finally
             rm(output_filename2)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,88 +5,122 @@ using Base.Test
 
 @testset "CSVFiles" begin
 
-array = collect(load(joinpath(@__DIR__, "data.csv")))
-@test length(array) == 3
-@test array == [@NT(Name="John",Age=34.,Children=2),@NT(Name="Sally",Age=54.,Children=1),@NT(Name="Jim",Age=23.,Children=0)]
+@testset "basic" begin
+    array = collect(load(joinpath(@__DIR__, "data.csv")))
+    @test length(array) == 3
+    @test array == [@NT(Name="John",Age=34.,Children=2),@NT(Name="Sally",Age=54.,Children=1),@NT(Name="Jim",Age=23.,Children=0)]
 
-output_filename = tempname() * ".csv"
+    output_filename = tempname() * ".csv"
 
-try
-    array |> save(output_filename)
+    try
+        array |> save(output_filename)
 
-    array2 = collect(load(output_filename))
+        array2 = collect(load(output_filename))
 
-    @test array == array2
-finally
-    gc()
-    rm(output_filename)
+        @test array == array2
+    finally
+        gc()
+        rm(output_filename)
+    end
 end
 
-csvf = load(joinpath(@__DIR__, "data.csv"))
+@testset "traits" begin
+    csvf = load(joinpath(@__DIR__, "data.csv"))
 
-@test IteratorInterfaceExtensions.isiterable(csvf) == true
-@test TableTraits.isiterabletable(csvf) == true
-
-array3 = [@NT(a=DataValue(3),b="df\"e"),@NT(a=DataValue{Int}(),b="something")]
-
-output_filename2 = tempname() * ".csv"
-
-try
-    array3 |> save(output_filename2)
-finally
-    rm(output_filename2)
+    @test IteratorInterfaceExtensions.isiterable(csvf) == true
+    @test TableTraits.isiterabletable(csvf) == true
 end
 
-array = collect(load("https://raw.githubusercontent.com/davidanthoff/CSVFiles.jl/v0.2.0/test/data.csv"))
-@test length(array) == 3
-@test array == [@NT(Name="John",Age=34.,Children=2),@NT(Name="Sally",Age=54.,Children=1),@NT(Name="Jim",Age=23.,Children=0)]
+@testset "missing values" begin
+    array3 = [@NT(a=DataValue(3),b="df\"e"),@NT(a=DataValue{Int}(),b="something")]
 
-output_filename3 = tempname() * ".tsv"
+    @testset "default" begin
+        output_filename2 = tempname() * ".csv"
 
-try
-    array |> save(output_filename3)
+        try
+            array3 |> save(output_filename2)
+        finally
+            rm(output_filename2)
+        end
+    end
 
-    array4 = collect(load(output_filename3))
-    @test length(array4) == 3
-    @test array4 == array
-finally
-    gc()
-    rm(output_filename3)
+    @testset "alternate" begin
+        output_filename2 = tempname() * ".csv"
+
+        try
+            array3 |> save(output_filename2, missingstring="")
+        finally
+            rm(output_filename2)
+        end
+    end
 end
 
-output_filename4 = tempname() * ".csv"
+@testset "Less Basic" begin
+    array = [@NT(Name="John",Age=34.,Children=2),@NT(Name="Sally",Age=54.,Children=1),@NT(Name="Jim",Age=23.,Children=0)]
+    @testset "remote loading" begin
+        rem_array = collect(load("https://raw.githubusercontent.com/davidanthoff/CSVFiles.jl/v0.2.0/test/data.csv"))
+        @test length(rem_array) == 3
+        @test rem_array == array
+    end
 
-try
-    array |> save(output_filename4, quotechar=nothing)
+    @testset "can round trip TSV" begin
+        output_filename3 = tempname() * ".tsv"
+        
+        try
+            array |> save(output_filename3)
+            
+            array4 = collect(load(output_filename3))
+            @test length(array4) == 3
+            @test array4 == array
+        finally
+            gc()
+            rm(output_filename3)
+        end
+    end
+    
+    @testset "no quote" begin
+        output_filename4 = tempname() * ".csv"
 
-finally
-    gc()
-    rm(output_filename4)
+        try
+            @show output_filename4
+            array |> save(output_filename4, quotechar=nothing)
+
+        finally
+            gc()
+            rm(output_filename4)
+        end
+    end
 end
 
-data = [@NT(Name="John",Age=34.,Children=2),@NT(Name="Sally",Age=54.,Children=1),@NT(Name="Jim",Age=23.,Children=0)]
+@testset "Streams" begin
+    data = [@NT(Name="John",Age=34.,Children=2),@NT(Name="Sally",Age=54.,Children=1),@NT(Name="Jim",Age=23.,Children=0)]
 
-stream = IOBuffer()
-mark(stream)
-fileiostream = FileIO.Stream(FileIO.format"CSV", stream)
-save(fileiostream, data)
-reset(stream)
-csvstream = load(fileiostream)
-reloaded_data = collect(csvstream)
-@test IteratorInterfaceExtensions.isiterable(csvstream)
-@test TableTraits.isiterabletable(csvstream)
-@test reloaded_data == data
+    @testset "CSV"  begin
+        stream = IOBuffer()
+        mark(stream)
+        fileiostream = FileIO.Stream(FileIO.format"CSV", stream)
+        save(fileiostream, data)
+        reset(stream)
+        csvstream = load(fileiostream)
+        reloaded_data = collect(csvstream)
+        @test IteratorInterfaceExtensions.isiterable(csvstream)
+        @test TableTraits.isiterabletable(csvstream)
+        @test reloaded_data == data
+    end
 
-stream = IOBuffer()
-mark(stream)
-fileiostream = FileIO.Stream(FileIO.format"TSV", stream)
-save(fileiostream, data)
-reset(stream)
-csvstream = load(fileiostream)
-reloaded_data = collect(csvstream)
-@test IteratorInterfaceExtensions.isiterable(csvstream)
-@test TableTraits.isiterabletable(csvstream)
-@test reloaded_data == data
-
+    @testset "TSV" begin
+        stream = IOBuffer()
+        mark(stream)
+        fileiostream = FileIO.Stream(FileIO.format"TSV", stream)
+        save(fileiostream, data)
+        reset(stream)
+        csvstream = load(fileiostream)
+        reloaded_data = collect(csvstream)
+        @test IteratorInterfaceExtensions.isiterable(csvstream)
+        @test TableTraits.isiterabletable(csvstream)
+        @test reloaded_data == data
+    end
 end
+
+end # Outer-most testset
 


### PR DESCRIPTION
I wanted to have the feature which was in [CSV.jl](http://juliadata.github.io/CSV.jl/stable/index.html#CSV.write) `missingstring`,  which lets you specify how missing values,
are written to file.
Without this PR they are written as "NA".
in latex PGFPlotstables really likes it if they are either empty strings, 
or `NaN`.

Probably this wants a similar PR in TextParser.jl so you can specify for reading purposes too?
But that can be latter

Also the number of identical kwargs in the different versions of `save` was bother me.
So I swapped them for some metaprogramming,
because I was worried I'ld miss one when copy-pasting.


Then I was trying to workout where to put it in the tests,
and I had trouble understanding what bits were testing what.
And I got a bit scared because it was all in one scope with all these variables floating around.
So I added testsets. Which actually ended up a bigger change by line-count than the feature I wanted.
Sorry If I over-stepped.
